### PR TITLE
Implemented XMLMatcher

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,1 +1,3 @@
 /ResolutionTest.class
+/XMLMatcher.class
+/XMLMatcherTest.class

--- a/tests/XMLMatcher.java
+++ b/tests/XMLMatcher.java
@@ -1,0 +1,61 @@
+package tests;
+
+import org.hamcrest.Description;
+import org.hamcrest.SelfDescribing;
+
+import processing.data.XML;
+
+public class XMLMatcher extends org.hamcrest.TypeSafeMatcher<XML> {
+
+	private final XML expectedRoot;
+	
+	public XMLMatcher(XML expectedTree) {
+		this.expectedRoot = expectedTree;
+	}
+
+	@Override
+	protected boolean matchesSafely(XML actualRoot) {
+		return matchesNodeName(actualRoot.getName()) && containsSameChildrenAs(actualRoot);
+	}
+	
+	private boolean matchesNodeName(String actualName) {
+		return expectedRoot.getName().equals(actualName);
+	}
+	
+	private boolean containsSameChildrenAs(XML actualRoot) {
+		return hasSameNumberOfChildrenAs(actualRoot) && allChildrenMatch(actualRoot);
+	}
+	
+	private boolean hasSameNumberOfChildrenAs(XML actualRoot) {
+		return expectedRoot.getChildCount() == actualRoot.getChildCount();
+	}
+	
+	private boolean allChildrenMatch(XML actualRoot) {
+		for(XML actualChild : actualRoot.getChildren()) {
+			if(!anyChildMatches(actualChild)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	private boolean anyChildMatches(XML actualChild) {
+		for(XML expectedChild : expectedRoot.getChildren()) {
+			if(new XMLMatcher(expectedChild).matchesSafely(actualChild)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public void describeTo(Description description) {
+		description.appendText("<" + expectedRoot.toString() + ">");
+		
+	}
+	
+	static public XMLMatcher equivalentTo(XML expectedTree) {
+		return new XMLMatcher(expectedTree);
+	}
+
+}

--- a/tests/XMLMatcherTest.java
+++ b/tests/XMLMatcherTest.java
@@ -1,0 +1,189 @@
+package tests;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+
+import org.junit.Test;
+
+import processing.core.PApplet;
+import processing.data.XML;
+
+import tests.XMLMatcher;
+
+public class XMLMatcherTest {
+	
+	XML expected, actual;
+
+	@Test
+	public void matchesSingleNode() {
+		givenExpected("<root/>");
+		givenActual("<root/>");
+		assertMatch();
+	}
+	
+	@Test
+	public void doesNotMatchDifferentNode() {
+		givenExpected("<root/>");
+		givenActual("<notTheRoot/>");
+		assertNoMatch();
+	}
+	
+	@Test
+	public void doesNotMatchExtraHierarchy() {
+		givenExpected("<root/>");
+		
+		givenActual(""
+				+ "<root>"
+				+ 	"<child1/>"
+				+ 	"<child2/>"
+				+ "</root>");
+		
+		assertNoMatch();
+	}
+	
+	@Test
+	public void doesNotMatchMissingHierarchy() {
+		givenExpected(""
+				+ "<root>"
+				+ 	"<child1/>"
+				+ 	"<child2/>"
+				+ "</root>");
+		
+		givenActual("<root/>");
+		
+		assertNoMatch();
+	}
+	
+	@Test
+	public void matchesSimpleSameHierarchy() {
+		givenExpected(
+				  "<root>"
+				+ 	"<child1/>"
+				+ 	"<child2/>"
+				+ "</root>");
+		
+		givenActual(""
+				+ "<root>"
+				+ 	"<child1/>"
+				+	"<child2/>"
+				+ "</root>");
+		
+		assertMatch();
+	}
+	
+	@Test
+	public void matchesSimpleEquivalentHierarchy() {
+		givenExpected(
+				  "<root>"
+				+ 	"<child1/>"
+				+ 	"<child2/>"
+				+ "</root>");
+		
+		givenActual(
+				  "<root>"
+				+ 	"<child2/>"
+				+ 	"<child1/>"
+				+ "</root>");
+		
+		assertMatch();
+	}
+	
+	@Test
+	public void doesNotMatchSimpleDifferentHierarchy() {
+		givenExpected(
+				  "<root>"
+				+ 	"<child1/>"
+				+ 	"<child2/>"
+				+ "</root>");
+		
+		givenActual(
+				  "<root>"
+				+ 	"<wrong_child/>"
+				+ 	"<child2/>"
+				+ "</root>");
+		
+		assertNoMatch();
+	}
+	
+	@Test
+	public void matchesComplexEquivalentHierarchy() {
+		givenExpected(
+				  "<root>"
+				+ 	"<child1>"
+				+ 		"<grandchild1/>"
+				+ 		"<grandchild2/>"
+				+ 	"</child1>"
+				+ 	"<child2>"
+				+ 		"<grandchild3/>"
+				+ 		"<grandchild4/>"
+				+ 	"</child2>"
+				+ "</root>");
+		
+		givenActual(
+				  "<root>"
+				+ 	"<child2>"
+				+ 		"<grandchild4/>"
+				+ 		"<grandchild3/>"
+				+ 	"</child2>"
+				+ 	"<child1>"
+				+ 		"<grandchild2/>"
+				+ 		"<grandchild1/>"
+				+ 	"</child1>"
+				+ "</root>");
+		
+		assertMatch();
+	}
+	
+	@Test
+	public void doesNotMatchComplexDifferentHierarchy() {
+		givenExpected(""
+				+ "<root>"
+				+ 	"<child1>"
+				+ 		"<grandchild1/>"
+				+ 		"<grandchild2/>"
+				+ 	"</child1>"
+				+ 	"<child2>"
+				+ 		"<grandchild3/>"
+				+ 	"</child2>"
+				+ "</root>");
+		
+		givenActual(""
+				+ "<root>"
+				+ 	"<child1>"
+				+ 		"<wrong_node/>"
+				+ 		"<grandchild2/>"
+				+ 	"</child1>"
+				+ 	"<child2>"
+				+ 		"<grandchild3/>"
+				+ 	"</child2>"
+				+ "</root>");
+		
+		assertNoMatch();
+	}
+	
+	private void givenExpected(String xmlString) {
+		expected = parse(xmlString);
+	}
+	
+	private void givenActual(String actualString) {
+		actual = parse(actualString);
+	}
+	
+	private XML parse(String xmlString) {
+		PApplet applet = new PApplet();
+		return applet.parseXML(xmlString);
+	}
+	
+	private void assertMatch() {
+		assertThat(actual, is(equivalentTreeTo(expected)));
+	}
+	
+	private void assertNoMatch() {
+		assertThat(actual, is(not(equivalentTreeTo(expected))));
+	}
+	
+	private XMLMatcher equivalentTreeTo(XML expected) {
+		return new XMLMatcher(expected);
+	}
+
+}


### PR DESCRIPTION
XMLMatcher extends the hamcrest BaseMatcher and matches two processing
XML objects by comparing their node value and their children in an
unordered fashion.
